### PR TITLE
fix: replace deprecated SessionRestore with AutoSession restore

### DIFF
--- a/lua/josean/plugins/alpha.lua
+++ b/lua/josean/plugins/alpha.lua
@@ -23,7 +23,7 @@ return {
       dashboard.button("SPC ee", "  > Toggle file explorer", "<cmd>NvimTreeToggle<CR>"),
       dashboard.button("SPC ff", "󰱼 > Find File", "<cmd>Telescope find_files<CR>"),
       dashboard.button("SPC fs", "  > Find Word", "<cmd>Telescope live_grep<CR>"),
-      dashboard.button("SPC wr", "󰁯  > Restore Session For Current Directory", "<cmd>SessionRestore<CR>"),
+      dashboard.button("SPC wr", "󰁯  > Restore Session For Current Directory", "<cmd>AutoSession restore<CR>"),
       dashboard.button("q", " > Quit NVIM", "<cmd>qa<CR>"),
     }
 


### PR DESCRIPTION
Replaces the deprecated SessionRestore command with the new AutoSession restore command in the alpha dashboard configuration.

Fixes #4

Generated with [Claude Code](https://claude.ai/code)